### PR TITLE
refactor: use cli.Flag Destination instead of urfave wrapper

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -32,10 +32,10 @@ If the file already exists, this command does nothing.
 
 func (lc *initCommand) action(ctx context.Context, logger *slogutil.Logger, flags *Flags) error {
 	ctrl := initcmd.NewController(afero.NewOsFs())
-	if err := logger.SetLevel(flags.LogLevel.V()); err != nil {
+	if err := logger.SetLevel(flags.LogLevel); err != nil {
 		return fmt.Errorf("set log level: %w", err)
 	}
-	if err := logger.SetColor(flags.LogColor.V()); err != nil {
+	if err := logger.SetColor(flags.LogColor); err != nil {
 		return fmt.Errorf("set log color: %w", err)
 	}
 	return ctrl.Init(ctx, logger.Logger) //nolint:wrapcheck

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -14,6 +14,12 @@ import (
 
 type runCommand struct{}
 
+type RunFlags struct {
+	*Flags
+
+	Args []string
+}
+
 func (rc *runCommand) command(logger *slogutil.Logger, flags *Flags) *cli.Command {
 	return &cli.Command{
 		Name:      "run",
@@ -23,26 +29,30 @@ func (rc *runCommand) command(logger *slogutil.Logger, flags *Flags) *cli.Comman
 
 $ yodoc run
 `,
-		Action: func(ctx context.Context, c *cli.Command) error {
-			return rc.action(ctx, c, logger, flags)
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			runFlags := &RunFlags{
+				Flags: flags,
+				Args:  cmd.Args().Slice(),
+			}
+			return rc.action(ctx, logger, runFlags)
 		},
 	}
 }
 
-func (rc *runCommand) action(ctx context.Context, cmd *cli.Command, logger *slogutil.Logger, flags *Flags) error {
+func (rc *runCommand) action(ctx context.Context, logger *slogutil.Logger, flags *RunFlags) error {
 	fs := afero.NewOsFs()
 	configReader := config.NewReader(fs)
 	renderer := render.NewRenderer(fs)
 	finder := config.NewFinder(fs)
 	ctrl := run.NewController(fs, finder, configReader, renderer)
-	if err := logger.SetLevel(flags.LogLevel.V()); err != nil {
+	if err := logger.SetLevel(flags.LogLevel); err != nil {
 		return fmt.Errorf("set log level: %w", err)
 	}
-	if err := logger.SetColor(flags.LogColor.V()); err != nil {
+	if err := logger.SetColor(flags.LogColor); err != nil {
 		return fmt.Errorf("set log color: %w", err)
 	}
 	return ctrl.Run(ctx, logger.Logger, &run.Param{ //nolint:wrapcheck
-		ConfigFilePath: flags.Config.V(),
-		Files:          cmd.Args().Slice(),
+		ConfigFilePath: flags.Config,
+		Files:          flags.Args,
 	})
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -41,37 +41,36 @@ func Run(version string) int {
 type Runner struct{}
 
 type Flags struct {
-	LogLevel *urfave.StringFlag
-	LogColor *urfave.StringFlag
-	Config   *urfave.StringFlag
+	LogLevel string
+	LogColor string
+	Config   string
 }
 
 func (r *Runner) Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
-	flags := &Flags{
-		LogLevel: urfave.String(&cli.StringFlag{
-			Name:    "log-level",
-			Usage:   "log level",
-			Sources: cli.EnvVars("YODOC_LOG_LEVEL"),
-		}),
-		LogColor: urfave.String(&cli.StringFlag{
-			Name:    "log-color",
-			Usage:   "Log color. One of 'auto' (default), 'always', 'never'",
-			Sources: cli.EnvVars("YODOC_LOG_COLOR"),
-		}),
-		Config: urfave.String(&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Configuration file path",
-			Sources: cli.EnvVars("YODOC_CONFIG"),
-		}),
-	}
+	flags := &Flags{}
 	return urfave.Command(env, &cli.Command{ //nolint:wrapcheck
 		Name:  "yodoc",
 		Usage: "Test command results and embed them into document",
 		Flags: []cli.Flag{
-			flags.LogLevel,
-			flags.LogColor,
-			flags.Config,
+			&cli.StringFlag{
+				Name:        "log-level",
+				Usage:       "log level",
+				Sources:     cli.EnvVars("YODOC_LOG_LEVEL"),
+				Destination: &flags.LogLevel,
+			},
+			&cli.StringFlag{
+				Name:        "log-color",
+				Usage:       "Log color. One of 'auto' (default), 'always', 'never'",
+				Sources:     cli.EnvVars("YODOC_LOG_COLOR"),
+				Destination: &flags.LogColor,
+			},
+			&cli.StringFlag{
+				Name:        "config",
+				Aliases:     []string{"c"},
+				Usage:       "Configuration file path",
+				Sources:     cli.EnvVars("YODOC_CONFIG"),
+				Destination: &flags.Config,
+			},
 		},
 		Commands: []*cli.Command{
 			(&initCommand{}).command(logger, flags),


### PR DESCRIPTION
Use standard urfave/cli/v3 Destination pattern for flag value binding instead of urfave-cli-v3-util's wrapper types with .V() method.

🤖 Generated with [Claude Code](https://claude.ai/code)